### PR TITLE
bugFix/contribCount

### DIFF
--- a/src/components/Wiki/Landing/Landing.tsx
+++ b/src/components/Wiki/Landing/Landing.tsx
@@ -12,7 +12,7 @@ interface landingProps{
 interface landingState{
     numEntries: number,
     numComments: number,
-    numContributors: number
+    allContributors: number[]
 }
 
 class Landing extends React.Component<landingProps, landingState>{
@@ -21,7 +21,7 @@ class Landing extends React.Component<landingProps, landingState>{
         this.state = {
             numEntries: 0,
             numComments: 0,
-            numContributors: 0
+            allContributors: []
         }
     }
 
@@ -35,10 +35,20 @@ class Landing extends React.Component<landingProps, landingState>{
                     }
                 })
                     .then(response => response.json())
-                    .then(data => this.setState({
-                        numComments: this.state.numComments + data['comments'].length,
-                        numContributors: this.state.numContributors + data['contributors'].length
-                    }))
+                    .then(data => {
+                        this.setState({
+                            numComments: this.state.numComments + data['comments'].length,
+                        })
+
+                        //if entry has contributors not accounted for, add to allContributors state var
+                        data['contributors'].forEach((contributorId: number) => {
+                            if(!this.state.allContributors.includes(contributorId)){
+                                this.setState({
+                                    allContributors: this.state.allContributors.concat(contributorId)
+                                })
+                            }
+                        })
+                    })
             })
             this.setState({
                 numEntries: this.props.entries.length
@@ -54,7 +64,7 @@ class Landing extends React.Component<landingProps, landingState>{
                         <Card.Title>This wiki has...</Card.Title>
                         <ul>
                             <li>{this.state.numEntries} entry (ies)</li>
-                            <li>{this.state.numContributors} contributor (s)</li>
+                            <li>{this.state.allContributors.length} contributor (s)</li>
                             <li>{this.state.numComments} comment (s)</li>
                         </ul>
                         <Card.Title>This wiki is...</Card.Title>


### PR DESCRIPTION
fixes #60 

changed Landing component's numContributors state var to allContributors state var, as we're fetching each entry we check if any of it's contributors aren't accounted for, if not we add them to allContributors state var. Then we render out the length of said var. <br><br><br> :cactus: 