### PR TITLE
feature/deleteHeadings

### DIFF
--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -6,7 +6,7 @@ import {entryData} from "../../../utils/getInterfaces/entryData";
 import {commentData} from "../../../utils/getInterfaces/commentData";
 import {headingData} from "../../../utils/getInterfaces/headingData";
 import {newCommentData} from "../../../utils/postInterfaces/newCommentData";
-
+import {deleteHeading} from "../EntryEditForm/deleteHeading";
 import {postComment} from "./postComment";
 
 import './Entry.css';
@@ -179,6 +179,7 @@ class Entry extends React.Component<entryProps, entryState>{
                                     <div>
                                         <Form.Control className="heading" value={data['title']}></Form.Control>
                                         <Form.Control value={data['text']} as="textarea" rows={4}></Form.Control>
+                                        <Button onClick={() => deleteHeading(data['id'])}variant="danger">Delete</Button>
                                     </div>
                                 )
                             })

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -39,51 +39,42 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
             deleteEntryModal: false,
             addHeadingModal: false
         }
-        this.handleEntryDeleteModalHide = this.handleEntryDeleteModalHide.bind(this);
-        this.handleEntryDeleteModalShow = this.handleEntryDeleteModalShow.bind(this);
-        this.handleNewHeadingModalHide = this.handleNewHeadingModalHide.bind(this);
-        this.handleNewHeadingModalShow = this.handleNewHeadingModalShow.bind(this);
-
-        this.handleEntryDeleteSubmit = this.handleEntryDeleteSubmit.bind(this);
-        this.handleEntryUpdateSubmit = this.handleEntryUpdateSubmit.bind(this);
-        this.handleNewHeadingSubmit = this.handleNewHeadingSubmit.bind(this);
-        this.buildSideBarElements = this.buildSideBarElements.bind(this);
     }
 
-    handleEntryDeleteModalHide(){
+    handleEntryDeleteModalHide = () => {
         this.setState({
             deleteEntryModal: false
         })
     }
 
-    handleEntryDeleteModalShow(){
+    handleEntryDeleteModalShow = () => {
         this.setState({
             deleteEntryModal: true
         })
     }
 
-    handleNewHeadingModalHide(){
+    handleNewHeadingModalHide = () => {
         this.setState({
             addHeadingModal: false
         })
     }
 
-    handleNewHeadingModalShow(){
+    handleNewHeadingModalShow = () =>{
         this.setState({
             addHeadingModal: true
         })
     }
 
-    handleEntryDeleteSubmit(){
+    handleEntryDeleteSubmit = () =>{
         deleteEntry(this.props.entryData);
     }
 
-    handleEntryUpdateSubmit(e: React.FormEvent<HTMLFormElement>){
+    handleEntryUpdateSubmit = (e: React.FormEvent<HTMLFormElement>) =>{
         e.preventDefault();
         updateEntry(this.state.entryData);
     }
 
-    handleNewHeadingSubmit(e: React.FormEvent<HTMLFormElement>){
+    handleNewHeadingSubmit = (e: React.FormEvent<HTMLFormElement>) =>{
         e.preventDefault();
         postNewHeading(
             this.state.newHeading,
@@ -128,7 +119,7 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
         })
     }
 
-    buildSideBarElements(){
+    buildSideBarElements = () =>{
         if(this.state.sideBarData.content !== null) {
             for (const [key, value] of Object.entries(this.state.sideBarData.content)) {
                 this.setState({

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -200,18 +200,18 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
                 </Modal>
                 <Form id="editForm" onSubmit={this.handleEntryUpdateSubmit}>
                     <Form.Group>
-                        <Form.Label className="editEntryLabel">Title</Form.Label>
+                        <Form.Label className="editEntryLabel"><u>Title</u></Form.Label>
                         <Form.Control id="title" name="title" onChange={this.handleEntryChange} value={this.state.entryData.title}></Form.Control>
-                        <Form.Label className="editEntryLabel">Description</Form.Label>
+                        <Form.Label className="editEntryLabel"><u>Description</u></Form.Label>
                         <Form.Control name="text" onChange={this.handleEntryChange} value={this.state.entryData.text}></Form.Control>
-                        <Form.Label className="editEntryLabel">Headings</Form.Label>
+                        <Form.Label className="editEntryLabel"><u>Headings</u></Form.Label>
                         {this.state.headingEditElements}
                     </Form.Group>
                     <Form.Group id="headingButton">
                         <Button onClick={this.handleNewHeadingModalShow}>Add Heading</Button>
                     </Form.Group>
                     <Form.Group id="sideBarLabelGroup">
-                        <Form.Label className="editEntryLabel">Sidebar</Form.Label>
+                        <Form.Label className="editEntryLabel"><u>Sidebar</u></Form.Label>
                     </Form.Group>
                     <Form.Group id="sideBarEdit" >
                         {this.state.sideBarElements}

--- a/src/components/Wiki/EntryEditForm/deleteHeading.ts
+++ b/src/components/Wiki/EntryEditForm/deleteHeading.ts
@@ -1,0 +1,16 @@
+import {url} from "../../../utils/DetermineUrl";
+
+export function deleteHeading(headingId: number){
+    fetch(url+'/heading/'+headingId, {
+        method: "DELETE",
+        headers:  {
+            "Content-Type": "application/json"
+        }
+    }).then(response => {
+        if(!response.ok){
+            console.log("Removing heading failed...");
+        }else{
+            window.location.reload()
+        }
+    })
+}


### PR DESCRIPTION
When the heading elements  are being generated, to be rendered in the edit tab, there is now a delete button that uses the added ```deleteHeading``` function. <br>

Also converted any functions in the EntryEditForm component to arrow functions, as to remove bindings.<br><br><br> :cactus: 
