### PR TITLE
feature/deleteWikis

### DIFF
--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -45,7 +45,8 @@ interface entryState{
 
 interface entryProps{
     id: string,
-    currentUser: userData
+    currentUser: userData,
+    wikiId: number,
 }
 
 //component has no props, hence {}
@@ -254,7 +255,7 @@ class Entry extends React.Component<entryProps, entryState>{
         if(this.props.currentUser.accountLevel === 0){
             editTabElements =
                 <Tab eventKey="edit" title="Edit" transition={false}>
-                    <EntryEditForm headingEditElements={this.state.headingEditElements} entryData={this.state.data} sideBarData={this.state.sideBar} currentUser={this.props.currentUser}></EntryEditForm>
+                    <EntryEditForm headingEditElements={this.state.headingEditElements} entryData={this.state.data} sideBarData={this.state.sideBar} currentUser={this.props.currentUser} wikiId={this.props.wikiId}></EntryEditForm>
                 </Tab>;
         }
         return(

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -218,7 +218,8 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
                     </Form.Group>
                     <Form.Group id="submitGroup">
                         <Button id="submitButton" variant="success" type="submit">Save</Button>
-                        <Button onClick={this.handleEntryDeleteModalShow} variant="danger" type="button">Delete Entry</Button>
+                        <Button onClick={this.handleEntryDeleteModalShow} variant="danger" type="button" className="mr-4">Delete Entry</Button>
+                        <Button onClick={() => console.log("delete wiki button hit")} variant="warning" type="button">Delete Wiki</Button>
                     </Form.Group>
                 </Form>
             </div>

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -197,7 +197,7 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
                         <Modal.Title>Confirmation</Modal.Title>
                     </Modal.Header>
                     <Modal.Body>
-                        <p>Confirm deletion of Wiki "<b>test</b>"</p>
+                        <p>Confirm deletion of current wiki</p>
                         <Button variant="danger" type="button" onClick={this.handleWikiDeleteSubmit}>Delete</Button>
                         <Button className="ml-4" variant="secondary" type="button" onClick={this.handleWikiDeleteModalHide}>Cancel</Button>
                     </Modal.Body>

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -23,6 +23,7 @@ interface entryEditFormState{
     headingEditElements: JSX.Element[],
     sideBarElements: JSX.Element[],
     newHeading: newHeadingData
+    deleteWikiModal: boolean
     deleteEntryModal: boolean
     addHeadingModal: boolean
 }
@@ -36,9 +37,22 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
             headingEditElements: [],
             sideBarElements: [],
             newHeading: {title: '', text: '', log: []},
+            deleteWikiModal: false,
             deleteEntryModal: false,
             addHeadingModal: false
         }
+    }
+
+    handleWikiDeleteModalHide = () => {
+        this.setState({
+            deleteWikiModal: false
+        })
+    }
+
+    handleWikiDeleteModalShow = () => {
+        this.setState({
+            deleteWikiModal: true
+        })
     }
 
     handleEntryDeleteModalHide = () => {
@@ -172,6 +186,14 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
     render(){
         return(
             <div>
+                <Modal id="deleteWikiModal" show={this.state.deleteWikiModal} onHide={this.handleWikiDeleteModalHide}>
+                    <Modal.Header closeButton>
+                        <Modal.Title>Confirmation</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <p>Confirm deletion of Wiki "<b>test</b>"</p>
+                    </Modal.Body>
+                </Modal>
                 <Modal id="deleteEntryModal" show={this.state.deleteEntryModal} onHide={this.handleEntryDeleteModalHide}>
                     <Modal.Header closeButton>
                         <Modal.Title>Confirmation</Modal.Title>
@@ -219,7 +241,7 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
                     <Form.Group id="submitGroup">
                         <Button id="submitButton" variant="success" type="submit">Save</Button>
                         <Button onClick={this.handleEntryDeleteModalShow} variant="danger" type="button" className="mr-4">Delete Entry</Button>
-                        <Button onClick={() => console.log("delete wiki button hit")} variant="warning" type="button">Delete Wiki</Button>
+                        <Button onClick={this.handleWikiDeleteModalShow} variant="warning" type="button">Delete Wiki</Button>
                     </Form.Group>
                 </Form>
             </div>

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -8,13 +8,15 @@ import {newHeadingData} from "../../../utils/postInterfaces/newHeadingData";
 import {sideBarData} from "../../../utils/getInterfaces/sideBarData";
 import {postHeading} from "./postHeading";
 import {userData} from "../../../utils/getInterfaces/userData";
+import {deleteWiki} from "../deleteWiki";
 
 
 interface entryEditFormProps{
     headingEditElements: JSX.Element[],
     entryData: entryData,
     sideBarData: sideBarData,
-    currentUser: userData
+    currentUser: userData,
+    wikiId: number
 }
 
 interface entryEditFormState{
@@ -77,6 +79,10 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
         this.setState({
             addHeadingModal: true
         })
+    }
+
+    handleWikiDeleteSubmit = () =>{
+        deleteWiki(this.props.wikiId);
     }
 
     handleEntryDeleteSubmit = () =>{
@@ -192,6 +198,8 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
                     </Modal.Header>
                     <Modal.Body>
                         <p>Confirm deletion of Wiki "<b>test</b>"</p>
+                        <Button variant="danger" type="button" onClick={this.handleWikiDeleteSubmit}>Delete</Button>
+                        <Button className="ml-4" variant="secondary" type="button" onClick={this.handleWikiDeleteModalHide}>Cancel</Button>
                     </Modal.Body>
                 </Modal>
                 <Modal id="deleteEntryModal" show={this.state.deleteEntryModal} onHide={this.handleEntryDeleteModalHide}>

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -6,7 +6,7 @@ import {entryData} from "../../../utils/getInterfaces/entryData";
 import './EntryEditForm.css';
 import {newHeadingData} from "../../../utils/postInterfaces/newHeadingData";
 import {sideBarData} from "../../../utils/getInterfaces/sideBarData";
-import {postNewHeading} from "./postNewHeading";
+import {postHeading} from "./postHeading";
 import {userData} from "../../../utils/getInterfaces/userData";
 
 
@@ -76,7 +76,7 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
 
     handleNewHeadingSubmit = (e: React.FormEvent<HTMLFormElement>) =>{
         e.preventDefault();
-        postNewHeading(
+        postHeading(
             this.state.newHeading,
             {
                 context: this.state.newHeading.title,

--- a/src/components/Wiki/EntryEditForm/postHeading.ts
+++ b/src/components/Wiki/EntryEditForm/postHeading.ts
@@ -3,7 +3,7 @@ import {newChangeData} from "../../../utils/postInterfaces/newChangeData";
 import {entryData} from "../../../utils/getInterfaces/entryData";
 import {url} from "../../../utils/DetermineUrl";
 
-export function postNewHeading(heading: newHeadingData, change: newChangeData, entryData: entryData){
+export function postHeading(heading: newHeadingData, change: newChangeData, entryData: entryData){
     fetch(url+'/change', {
         method: 'POST',
         body: JSON.stringify(change),

--- a/src/components/Wiki/Wiki.tsx
+++ b/src/components/Wiki/Wiki.tsx
@@ -107,7 +107,7 @@ class Wiki extends React.Component<wikiProps, wikiState>{
         }
 
         let rightPaneComponent;
-        this.state.view === "landing" ? rightPaneComponent = <Landing entries={this.state.data.entries} wikiDescription={this.state.data.briefDescription}/> : rightPaneComponent = <Entry id={this.state.view} currentUser={this.state.currentUser}/>
+        this.state.view === "landing" ? rightPaneComponent = <Landing entries={this.state.data.entries} wikiDescription={this.state.data.briefDescription}/> : rightPaneComponent = <Entry id={this.state.view} currentUser={this.state.currentUser} wikiId={this.state.data.id}/>
         
         return(
             <section style={background}>

--- a/src/components/Wiki/deleteWiki.ts
+++ b/src/components/Wiki/deleteWiki.ts
@@ -1,8 +1,8 @@
 import {url} from "../../utils/DetermineUrl";
 
 export function deleteWiki(wikiId: number){
-    fetch(url+'/wiki/'+wikiId, {
-        method: "DELETE",
+    fetch(url+'/wiki/delete_wiki?id='+wikiId, {
+        method: "GET",
         headers:  {
             "Content-Type": "application/json"
         }

--- a/src/components/Wiki/deleteWiki.ts
+++ b/src/components/Wiki/deleteWiki.ts
@@ -1,0 +1,16 @@
+import {url} from "../../utils/DetermineUrl";
+
+export function deleteWiki(wikiId: number){
+    fetch(url+'/wiki/'+wikiId, {
+        method: "DELETE",
+        headers:  {
+            "Content-Type": "application/json"
+        }
+    }).then(response => {
+        if(!response.ok){
+            console.log("Wiki deletion failed...");
+        }else{
+            window.location.reload()
+        }
+    })
+}

--- a/src/components/Wiki/deleteWiki.ts
+++ b/src/components/Wiki/deleteWiki.ts
@@ -10,7 +10,7 @@ export function deleteWiki(wikiId: number){
         if(!response.ok){
             console.log("Wiki deletion failed...");
         }else{
-            window.location.reload()
+            window.location.href="/home";
         }
     })
 }


### PR DESCRIPTION
This adds a new button to the edit tab, which allows users to delete the current wiki.  

- Will pop a confirmation modal
- Deletes wiki obj and all the entries associated with a wiki and their relations
- Also changed ```postNewHeading.ts``` to ```postHeading.ts``` and the function name inside the file the same.  
<br><br><br>:cactus: 