### PR TITLE
bugFix/deleteHeadings

### DIFF
--- a/src/components/Wiki/EntryEditForm/deleteHeading.ts
+++ b/src/components/Wiki/EntryEditForm/deleteHeading.ts
@@ -1,8 +1,8 @@
 import {url} from "../../../utils/DetermineUrl";
 
 export function deleteHeading(headingId: number){
-    fetch(url+'/heading/'+headingId, {
-        method: "DELETE",
+    fetch(url+'/heading/delete_heading?id='+headingId, {
+        method: "GET",
         headers:  {
             "Content-Type": "application/json"
         }


### PR DESCRIPTION
uses new backend route ```/delete_heading```, which now gets rid of any relations for the heading chosen <br><br><br> :cactus: 