### PR TITLE
bugFix/loginCSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ coverage/
 package-lock.json
 .idea/
 webpack-stats.json
+.directory

--- a/src/components/LogIn/LogIn.css
+++ b/src/components/LogIn/LogIn.css
@@ -49,10 +49,6 @@
 
 .loginTextInput{
     margin-top: .3rem;
-    padding-left: .5rem;
-    font-size: 12pt;
-    line-height: 2;
-    width: 50%;
 }
 
 #loginButton{


### PR DESCRIPTION
closes #89 

- removed any styling attributes for class ```.loginTextInput``` that get overwritten by ```.form-control```. 