### PR TITLE
feature/changeViewing

### DIFF
--- a/src/components/Wiki/Entry/Entry.css
+++ b/src/components/Wiki/Entry/Entry.css
@@ -68,7 +68,7 @@
     border: none !important;
 }
 
-.comment{
+.comment, .change{
     margin-left: auto;
     margin-right: auto;
     margin-top: 2%;
@@ -80,7 +80,7 @@
     border: none !important;
 }
 
-.comment .toast-header{
+.comment .toast-header, .change .toast-header{
     background-color: #181a1b;
     border-bottom: none;
     color: white;

--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -314,6 +314,9 @@ class Entry extends React.Component<entryProps, entryState>{
                     {this.state.commentElements}
 
                 </Tab>
+                <Tab eventKey="changes" title="Changes" transition={false}>
+                    {this.state.changeElements}
+                </Tab>
                 {editTabElements}
             </Tabs>
         );

--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -227,7 +227,6 @@ class Entry extends React.Component<entryProps, entryState>{
         //get change data/build elements, reverse sort as to sort (newest -> oldest)
         let responseChanges = await getAllChanges(this.props.id);
         let jsonChanges = await responseChanges.json();
-        jsonChanges.reverse();
 
         for(const change of jsonChanges){
             let responseUser = await getUser(change['user']);

--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -5,13 +5,14 @@ import EntryEditForm from "../EntryEditForm/EntryEditForm";
 import {entryData} from "../../../utils/getInterfaces/entryData";
 import {commentData} from "../../../utils/getInterfaces/commentData";
 import {headingData} from "../../../utils/getInterfaces/headingData";
+import {changeData} from "../../../utils/getInterfaces/changeData";
 import {newCommentData} from "../../../utils/postInterfaces/newCommentData";
 
 import './Entry.css';
 import {sideBarData} from "../../../utils/getInterfaces/sideBarData";
 import {userData} from "../../../utils/getInterfaces/userData";
 import {wikiData} from "../../../utils/getInterfaces/wikiData";
-import {getEntry, getComment, getUser, getHeading, getSideBar, postComment, deleteComment} from "./apiCalls";
+import {getEntry, getComment, getUser, getHeading, getSideBar, postComment, deleteComment, getChange} from "./apiCalls";
 const logo = require('../../../images/swarmLogoIcon.png');
 
 /*

--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -81,7 +81,9 @@ class Entry extends React.Component<entryProps, entryState>{
             commentElements: [],
             newComment: {text: '', user: 0},
             headings: [],
-            headingElements: []
+            headingElements: [],
+            changes: [],
+            changeElements: []
         }, () => {
             this.getEntry();
         })

--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -227,8 +227,24 @@ class Entry extends React.Component<entryProps, entryState>{
             let responseChange = await getChange(changeId);
             let jsonChange = await responseChange.json();
 
+            let responseUser = await getUser(jsonChange['user']);
+            let jsonUser = await responseUser.json();
+
             this.setState({
-                changes: this.state.changes.concat(jsonChange as changeData)
+                changes: this.state.changes.concat(jsonChange as changeData),
+                changeElements: this.state.changeElements.concat(
+                    <Toast className={'change'}>
+                        <Toast.Header>
+                            <Image src={logo} roundedCircle width={25} height={25}/>
+                            <strong className={'ml-2 mr-auto'}>{jsonUser['username']}</strong>
+                            <small className="mr-1">{jsonChange['dateTime'].substring(0,10)+" "+jsonChange['dateTime'].substring(11,19)}</small>
+                        </Toast.Header>
+                        <Toast.Body>
+                            <h5>{jsonChange['context']}</h5>
+                            <p>{jsonChange['textAdded']}</p>
+                        </Toast.Body>
+                    </Toast>
+                )
             })
         }
     }

--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -224,7 +224,8 @@ class Entry extends React.Component<entryProps, entryState>{
             }
         }
 
-        //get change data/build elements
+        //get change data/build elements, reverse sort as to sort (newest -> oldest)
+        jsonEntries['log'].reverse();
         for(const changeId of jsonEntries['log']){
             let responseChange = await getChange(changeId);
             let jsonChange = await responseChange.json();

--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -39,6 +39,8 @@ interface entryState{
     newComment: newCommentData
     headings: headingData[]
     headingElements: JSX.Element[]
+    changes: changeData[]
+    changeElements: JSX.Element[]
 }
 
 interface entryProps{
@@ -65,6 +67,8 @@ class Entry extends React.Component<entryProps, entryState>{
             newComment: {text: '', user: 0},
             headings: [],
             headingElements: [],
+            changes: [],
+            changeElements: []
         };
     }
 
@@ -216,6 +220,16 @@ class Entry extends React.Component<entryProps, entryState>{
                     )
                 })
             }
+        }
+
+        //get change data/build elements
+        for(const changeId of jsonEntries['log']){
+            let responseChange = await getChange(changeId);
+            let jsonChange = await responseChange.json();
+
+            this.setState({
+                changes: this.state.changes.concat(jsonChange as changeData)
+            })
         }
     }
 

--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -229,7 +229,7 @@ class Entry extends React.Component<entryProps, entryState>{
         let jsonChanges = await responseChanges.json();
 
         for(const change of jsonChanges){
-            let responseUser = await getUser(change['user']);
+            let responseUser = await getUser(change['user_id']);
             let jsonUser = await responseUser.json();
             this.setState({
                 changes: this.state.changes.concat(change as changeData),
@@ -271,7 +271,7 @@ class Entry extends React.Component<entryProps, entryState>{
 
     render(){
         let editTabElements: JSX.Element = <></>
-        if(this.props.currentUser.accountLevel === 0 && this.state.data.id !== 0 && this.state.headings !== []){
+        if(this.props.currentUser.accountLevel === 0 && this.state.data.id !== 0 && this.state.headings.length === this.state.data.headings.length){
             editTabElements =
                 <Tab eventKey="edit" title="Edit" transition={false}>
                     <EntryEditForm initHeadingData={this.state.headings} entryData={this.state.data} sideBarData={this.state.sideBar} currentUser={this.props.currentUser} wiki={this.props.wiki} reloadEntry={this.reloadEntry} reloadWiki={this.props.reloadWiki}></EntryEditForm>

--- a/src/components/Wiki/Entry/Entry.tsx
+++ b/src/components/Wiki/Entry/Entry.tsx
@@ -12,7 +12,7 @@ import './Entry.css';
 import {sideBarData} from "../../../utils/getInterfaces/sideBarData";
 import {userData} from "../../../utils/getInterfaces/userData";
 import {wikiData} from "../../../utils/getInterfaces/wikiData";
-import {getEntry, getComment, getUser, getHeading, getSideBar, postComment, deleteComment, getChange} from "./apiCalls";
+import {getEntry, getComment, getUser, getHeading, getSideBar, postComment, deleteComment, getAllChanges} from "./apiCalls";
 const logo = require('../../../images/swarmLogoIcon.png');
 
 /*
@@ -225,26 +225,25 @@ class Entry extends React.Component<entryProps, entryState>{
         }
 
         //get change data/build elements, reverse sort as to sort (newest -> oldest)
-        jsonEntries['log'].reverse();
-        for(const changeId of jsonEntries['log']){
-            let responseChange = await getChange(changeId);
-            let jsonChange = await responseChange.json();
+        let responseChanges = await getAllChanges(this.props.id);
+        let jsonChanges = await responseChanges.json();
+        jsonChanges.reverse();
 
-            let responseUser = await getUser(jsonChange['user']);
+        for(const change of jsonChanges){
+            let responseUser = await getUser(change['user']);
             let jsonUser = await responseUser.json();
-
             this.setState({
-                changes: this.state.changes.concat(jsonChange as changeData),
+                changes: this.state.changes.concat(change as changeData),
                 changeElements: this.state.changeElements.concat(
                     <Toast className={'change'}>
                         <Toast.Header>
                             <Image src={logo} roundedCircle width={25} height={25}/>
                             <strong className={'ml-2 mr-auto'}>{jsonUser['username']}</strong>
-                            <small className="mr-1">{jsonChange['dateTime'].substring(0,10)+" "+jsonChange['dateTime'].substring(11,19)}</small>
+                            <small className="mr-1">{change['dateTime'].substring(0,10)+" "+change['dateTime'].substring(11,19)}</small>
                         </Toast.Header>
                         <Toast.Body>
-                            <h5>{jsonChange['context']}</h5>
-                            <p>{jsonChange['textAdded']}</p>
+                            <h5>{change['context']}</h5>
+                            <p>{change['textAdded']}</p>
                         </Toast.Body>
                     </Toast>
                 )

--- a/src/components/Wiki/Entry/apiCalls.ts
+++ b/src/components/Wiki/Entry/apiCalls.ts
@@ -51,6 +51,16 @@ export async function getSideBar(sideBarId: string){
     return response;
 }
 
+export async function getChange(changeId: string){
+    let response = await fetch(url+'/change/'+changeId, {
+        method: 'GET',
+        headers:{
+            'Content-Type': 'application/json'
+        }
+    })
+    return response;
+}
+
 export async function postComment(comment: newCommentData, comments: number[], entryId: number){
     let responseComment = await fetch(url+'/comment', {
         method: "POST",

--- a/src/components/Wiki/Entry/apiCalls.ts
+++ b/src/components/Wiki/Entry/apiCalls.ts
@@ -51,16 +51,6 @@ export async function getSideBar(sideBarId: string){
     return response;
 }
 
-export async function getChange(changeId: string){
-    let response = await fetch(url+'/change/'+changeId, {
-        method: 'GET',
-        headers:{
-            'Content-Type': 'application/json'
-        }
-    })
-    return response;
-}
-
 export async function postComment(comment: newCommentData, comments: number[], entryId: number){
     let responseComment = await fetch(url+'/comment', {
         method: "POST",

--- a/src/components/Wiki/Entry/apiCalls.ts
+++ b/src/components/Wiki/Entry/apiCalls.ts
@@ -104,3 +104,14 @@ export async function deleteComment(commentId: number){
     })
     return response;
 }
+
+export async function getAllChanges(entryId: string){
+    let response = await fetch(url+'/entry/get_all_changes?id='+entryId, {
+        method: "GET",
+        headers:  {
+            "Content-Type": "application/json"
+        }
+    })
+
+    return response;
+}

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -115,11 +115,19 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
 
     handleEditFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        let responseUpdateEntry = await updateEntry(this.state.entryData);
-        if(!responseUpdateEntry.ok){
-            console.log('Entry update failed...');
-        }
 
+        if(this.state.entryData !== this.props.entryData){
+            let responseUpdateEntry = await updateEntry(this.state.entryData,
+                {
+                    context: this.state.entryData.title,
+                    textAdded: this.state.entryData.text,
+                    user: this.props.currentUser.id
+                });
+            if(!responseUpdateEntry.ok){
+                console.log('Entry update failed...');
+            }
+        }
+        
         let responseUpdateWiki = await updateWiki(this.state.wikiData);
         if(!responseUpdateWiki.ok){
             console.log('Wiki update failed...');

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -241,23 +241,22 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
     }
 
     buildHeadingEditElements = () => {
-        if(this.state.headingData.length > 0) {
-            for(const heading of this.state.headingData) {
-                this.setState({
-                    headingEditElements: this.state.headingEditElements.concat(
-                        <div>
-                            <Form.Control id={this.state.headingData.indexOf(heading).toString()} className="heading" as="input"
-                                          defaultValue={heading.title} name="title"
-                                          onChange={this.handleHeadingChange}></Form.Control>
-                            <Form.Control id={this.state.headingData.indexOf(heading).toString()} defaultValue={heading.text} as="textarea"
-                                          rows={4} name="text" onChange={this.handleHeadingChange}></Form.Control>
-                            <Button onClick={() => this.handleDeleteHeadingSubmit(heading.id.toString())}
-                                    variant="danger">Delete</Button>
-                        </div>
-                    )
-                })
-            }
+        let headingElements: JSX.Element[] = [];
+
+        for(const heading of this.props.initHeadingData) {
+            headingElements.push(
+                <div>
+                    <Form.Control id={this.state.headingData.indexOf(heading).toString()} className="heading" as="input"
+                                  defaultValue={heading.title} name="title"
+                                  onChange={this.handleHeadingChange}></Form.Control>
+                    <Form.Control id={this.state.headingData.indexOf(heading).toString()} defaultValue={heading.text} as="textarea"
+                                  rows={4} name="text" onChange={this.handleHeadingChange}></Form.Control>
+                    <Button onClick={() => this.handleDeleteHeadingSubmit(heading.id.toString())}
+                            variant="danger">Delete</Button>
+                </div>
+            )
         }
+        this.setState({headingEditElements: headingElements});
     }
 
     componentDidUpdate(prevProps: Readonly<entryEditFormProps>, prevState: Readonly<entryEditFormState>, snapshot?: any) {
@@ -285,19 +284,16 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
     }
 
     componentDidMount() {
-        setTimeout( () => {
-            this.setState({
-                entryData: this.props.entryData,
-                sideBarData: this.props.sideBarData,
-                sideBarElements: [],
-                headingData: this.props.initHeadingData,
-                headingEditElements: []
-            }, () => {
-                this.buildSideBarElements();
-                this.buildHeadingEditElements();
-            });
-        }, 200)
-
+        this.setState({
+            entryData: this.props.entryData,
+            sideBarData: this.props.sideBarData,
+            sideBarElements: [],
+            headingData: this.props.initHeadingData,
+            headingEditElements: []
+        }, () => {
+            this.buildSideBarElements();
+            this.buildHeadingEditElements();
+        });
     }
 
     render(){

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -135,7 +135,7 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
 
         for(const heading of this.state.headingData){
             let originalHeadingData = this.props.initHeadingData.filter(function(headingOriginal){
-                return headingOriginal.id == heading.id;
+                return headingOriginal.id === heading.id;
             })[0]
 
             if(originalHeadingData !== heading){

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -139,7 +139,12 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
             })[0]
 
             if(originalHeadingData !== heading){
-                let responseHeading = await updateHeadings(heading);
+                let responseHeading = await updateHeadings(heading,
+                    {
+                        context: heading.title,
+                        textAdded: heading.text,
+                        user: this.props.currentUser.id
+                    });
                 if(!responseHeading.ok){
                     console.log("Heading '"+heading.title+"' update failed...");
                 }

--- a/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
+++ b/src/components/Wiki/EntryEditForm/EntryEditForm.tsx
@@ -127,16 +127,22 @@ class EntryEditForm extends React.Component<entryEditFormProps, entryEditFormSta
                 console.log('Entry update failed...');
             }
         }
-        
+
         let responseUpdateWiki = await updateWiki(this.state.wikiData);
         if(!responseUpdateWiki.ok){
             console.log('Wiki update failed...');
         }
 
         for(const heading of this.state.headingData){
-            let responseHeading = await updateHeadings(heading);
-            if(!responseHeading.ok){
-                console.log("Heading '"+heading.title+"' update failed...");
+            let originalHeadingData = this.props.initHeadingData.filter(function(headingOriginal){
+                return headingOriginal.id == heading.id;
+            })[0]
+
+            if(originalHeadingData !== heading){
+                let responseHeading = await updateHeadings(heading);
+                if(!responseHeading.ok){
+                    console.log("Heading '"+heading.title+"' update failed...");
+                }
             }
         }
 

--- a/src/components/Wiki/EntryEditForm/apiCalls.ts
+++ b/src/components/Wiki/EntryEditForm/apiCalls.ts
@@ -96,16 +96,31 @@ export async function updateWiki(wiki: wikiData){
     return response;
 }
 
-export async function updateHeadings(heading: headingData){
-    let response = await fetch(url+'/heading/'+heading.id, {
-        method: "PUT",
-        body: JSON.stringify(heading),
+export async function updateHeadings(heading: headingData, change: newChangeData){
+    let changeResponse = await fetch(url+'/change', {
+        method: 'POST',
+        body: JSON.stringify(change),
         headers: {
-            "Content-Type": "application/json"
+            'Content-Type': 'application/json'
         }
     })
 
-    return response;
+    if(!changeResponse.ok){
+        console.log("Saving new change failed...");
+        return changeResponse;
+    }else {
+        let changeJson = await changeResponse.json();
+        heading.log.push(changeJson['id']);
+        let response = await fetch(url + '/heading/' + heading.id, {
+            method: "PUT",
+            body: JSON.stringify(heading),
+            headers: {
+                "Content-Type": "application/json"
+            }
+        })
+
+        return response;
+    }
 }
 
 export async function deleteHeading(headingId: string){

--- a/src/components/Wiki/EntryEditForm/apiCalls.ts
+++ b/src/components/Wiki/EntryEditForm/apiCalls.ts
@@ -56,16 +56,32 @@ export async function postHeading(heading: newHeadingData, change: newChangeData
     }
 }
 
-export async function updateEntry(entry: entryData){
-    let response = await fetch(url+'/entry/'+entry.id, {
-        method: "PUT",
-        body: JSON.stringify(entry),
+export async function updateEntry(entry: entryData, change: newChangeData){
+    let changeResponse = await fetch(url+'/change', {
+        method: 'POST',
+        body: JSON.stringify(change),
         headers: {
-            "Content-Type": "application/json"
+            'Content-Type': 'application/json'
         }
     })
 
-    return response;
+    if(!changeResponse.ok){
+        console.log("Saving new change failed...");
+        return changeResponse;
+    }else{
+        let changeJson = await changeResponse.json();
+        entry.log.push(changeJson['id']);
+
+        let response = await fetch(url+'/entry/'+entry.id, {
+            method: "PUT",
+            body: JSON.stringify(entry),
+            headers: {
+                "Content-Type": "application/json"
+            }
+        })
+
+        return response;
+    }
 }
 
 export async function updateWiki(wiki: wikiData){

--- a/src/utils/getInterfaces/changeData.ts
+++ b/src/utils/getInterfaces/changeData.ts
@@ -1,0 +1,7 @@
+export interface changeData{
+    id: number,
+    dateTime: string,
+    context: string,
+    textAdded: string,
+    user: number
+}


### PR DESCRIPTION
closes #99

- also includes fix for [this](https://github.com/YCP-Swarm-Robotics-Capstone-2020-2021/swarm-website-backend/issues/75) issue

- added a new `Changes` tab for wikis
- uses new `api/entry/get_all_changes` route to get a list of changes for a given entry and it's headings
- log entry/heading changes only when there was an update to them, this is checked with a props/state comparison, 
as `EntryEditForm` gets initial heading/entry data via props then loads it into state to be updated